### PR TITLE
Updating httpposion and adding end_point configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ key [here](https://www.binance.com/userCenter/createApi.html)):
 ```
 config :binance,
   api_key: "xxx",
-  secret_key: "xxx"
+  secret_key: "xxx",
+  end_point: "https://api.binance.us" # Add for the US API end point. The default is for "https://api.binance.com"
 ```
 
 ## Usage

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,8 @@ use Mix.Config
 
 config :binance,
   api_key: "",
-  secret_key: ""
+  secret_key: "",
+  end_point: "https://api.binance.com"
 
 config :exvcr,
   filter_request_headers: [

--- a/lib/binance/rest/http_client.ex
+++ b/lib/binance/rest/http_client.ex
@@ -1,5 +1,5 @@
 defmodule Binance.Rest.HTTPClient do
-  @endpoint "https://api.binance.com"
+  @endpoint "https://api.binance.us"
 
   def get_binance(url, headers \\ []) do
     HTTPoison.get("#{@endpoint}#{url}", headers)

--- a/lib/binance/rest/http_client.ex
+++ b/lib/binance/rest/http_client.ex
@@ -1,5 +1,5 @@
 defmodule Binance.Rest.HTTPClient do
-  @endpoint "https://api.binance.us"
+  @endpoint Application.get_env(:binance, :end_point)
 
   def get_binance(url, headers \\ []) do
     HTTPoison.get("#{@endpoint}#{url}", headers)

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Binance.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:httpoison, "~> 1.0"},
+      {:httpoison, "~> 1.4"},
       {:poison, "~> 4.0.0"},
       {:exconstructor, "~> 1.1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},


### PR DESCRIPTION
Updating the httpposion because of this [issue hackney 591](https://github.com/benoitc/hackney/issues/591)

Adding a `end_point` configuration attribute to `config.exs` for the api end_point to allow for configurations pointing to the US binance API endpoint. The default remains the same. There should be no impact or changes required for existing applications pointing to the default API. 