### PR TITLE
Avoid scientific notation when formatting prices in order requests

### DIFF
--- a/fixture/vcr_cassettes/order_limit_buy_very_low_price.json
+++ b/fixture/vcr_cassettes/order_limit_buy_very_low_price.json
@@ -1,0 +1,91 @@
+[
+  {
+    "request": {
+      "body": "price=0.00000100&quantity=100&recvWindow=1000&side=BUY&symbol=DOGEBTC&timeInForce=GTC&timestamp=1616078020854&type=LIMIT&signature=***",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.binance.com/api/v3/order"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"symbol\":\"DOGEBTC\",\"orderId\":71845546,\"orderListId\":-1,\"clientOrderId\":\"cyNmMk8rcgunB0REmUlbyv\",\"transactTime\":1616078021041,\"price\":\"0.00000100\",\"origQty\":\"100.00000000\",\"executedQty\":\"0.00000000\",\"cummulativeQuoteQty\":\"0.00000000\",\"status\":\"NEW\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"side\":\"BUY\",\"fills\":[]}",
+      "headers": {
+        "Content-Type": "application/json;charset=UTF-8",
+        "Content-Length": "308",
+        "Connection": "keep-alive",
+        "Date": "Thu, 18 Mar 2021 14:33:41 GMT",
+        "Server": "nginx",
+        "Vary": "Accept-Encoding",
+        "x-mbx-uuid": "96b2626a-ef8b-4acb-8e9d-d9be9fb8015b",
+        "x-mbx-used-weight": "2",
+        "x-mbx-used-weight-1m": "2",
+        "x-mbx-order-count-10s": "1",
+        "x-mbx-order-count-1d": "2",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Xss-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Security-Policy": "default-src 'self'",
+        "X-Content-Security-Policy": "default-src 'self'",
+        "X-WebKit-CSP": "default-src 'self'",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 ecaa40073bdefd3aeab35205d96e7782.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "AMS50-C1",
+        "X-Amz-Cf-Id": "oEG1SOwjjbbn69nF5DIS-OLL8LGDCietCe9p84LasPsQVJg0zBbk5w=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "price=1.0e-6&quantity=100&recvWindow=1000&side=BUY&symbol=DOGEBTC&timeInForce=GTC&timestamp=1616079294199&type=LIMIT&signature=***",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.binance.com/api/v3/order"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"code\":-1100,\"msg\":\"Illegal characters found in parameter 'price'; legal range is '^([0-9]{1,20})(\\\\.[0-9]{1,20})?$'.\"}",
+      "headers": {
+        "Content-Type": "application/json;charset=UTF-8",
+        "Content-Length": "120",
+        "Connection": "keep-alive",
+        "Date": "Thu, 18 Mar 2021 14:54:56 GMT",
+        "Server": "nginx",
+        "x-mbx-uuid": "4fd90da0-9b2f-4d49-9bfd-732f5cd45d49",
+        "x-mbx-used-weight": "2",
+        "x-mbx-used-weight-1m": "2",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Xss-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Security-Policy": "default-src 'self'",
+        "X-Content-Security-Policy": "default-src 'self'",
+        "X-WebKit-CSP": "default-src 'self'",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "X-Cache": "Error from cloudfront",
+        "Via": "1.1 d8c5e23736c47a3e5184b0a78042898f.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "AMS50-C1",
+        "X-Amz-Cf-Id": "GfcWqCuwBeF9My8picPaBdLmQ8FKeyZzZqdUPwVqARACJIFJsi6jWg=="
+      },
+      "status_code": 400,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/binance.ex
+++ b/lib/binance.ex
@@ -204,12 +204,14 @@ defmodule Binance do
           else: %{}
         )
       )
-      |> Map.merge(unless(is_nil(stop_price), do: %{stopPrice: stop_price}, else: %{}))
+      |> Map.merge(
+        unless(is_nil(stop_price), do: %{stopPrice: format_price(stop_price)}, else: %{})
+      )
       |> Map.merge(
         unless(is_nil(new_client_order_id), do: %{icebergQty: iceberg_quantity}, else: %{})
       )
       |> Map.merge(unless(is_nil(time_in_force), do: %{timeInForce: time_in_force}, else: %{}))
-      |> Map.merge(unless(is_nil(price), do: %{price: price}, else: %{}))
+      |> Map.merge(unless(is_nil(price), do: %{price: format_price(price)}, else: %{}))
 
     case HTTPClient.post_binance("/api/v3/order", arguments) do
       {:ok, %{"code" => code, "msg" => msg}} ->
@@ -347,6 +349,9 @@ defmodule Binance do
   end
 
   # Misc
+
+  defp format_price(num) when is_float(num), do: :erlang.float_to_binary(num, [{:decimals, 8}])
+  defp format_price(num) when is_integer(num), do: inspect(num)
 
   @doc """
   Searches and normalizes the symbol as it is listed on binance.

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Binance.MixProject do
       {:exconstructor, "~> 1.1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:mix_test_watch, "~> 0.5", only: :dev, runtime: false},
-      {:exvcr, "~> 0.10.1", only: :test}
+      {:exvcr, "~> 0.12.2", only: :test}
     ]
   end
 

--- a/test/binance_test.exs
+++ b/test/binance_test.exs
@@ -434,7 +434,7 @@ defmodule BinanceTest do
         assert order.executed_qty == "0.00000000"
         assert order.iceberg_qty == nil
         assert order.is_working == nil
-        assert order.order_id == 212217782
+        assert order.order_id == 212_217_782
         assert order.orig_qty == "100.00000000"
         assert order.price == "0.30000000"
         assert order.side == "BUY"


### PR DESCRIPTION
## Problem description

In the current version of the library, if the price of the buy order is lower than `0.0001` it triggers the `inspect` function to use the scientific notation. This is an issue, as values formatted this way are not valid prices, as far as the request to the Binance API is concerned:

```elixir
iex> Binance.order_limit_buy("DOGEBTC", 100, 0.000001) # request body is "price=1.0e-6&quantity=..."
** (FunctionClauseError) no function clause matching in Binance.parse_order_response/1

The following arguments were given to Binance.parse_order_response/1:

# 1
{:error, {:binance_error, %{code: -1100, msg: "Illegal characters found in parameter 'price'; legal range is '^([0-9]{1,20})(\\.[0-9]{1,20})?$'."}}}
```

## Proposed changes

This PR modifies the `Binance.create_order/11` function to format `float` prices to always use 8 decimal places.
Its correctness is guaranteed by a unit test that matches one of the two recorded VCR cassettes, based on the `price` parameter in the request body. For that to be possible, I needed to bump the `exvcr` dependency to `0.12.2`.
