### PR TITLE
Update CI to test for OTP 22 & OTP 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        elixir: [1.9.4, 1.12.1]
+        elixir: [1.12.1]
         otp: [22.2, 24.0.2]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,12 @@ on:
       - v*
   pull_request:
 
-strategy:
-  matrix:
-    elixir: [1.9.4, 1.12.1]
-    otp: [22.2, 24.0.2]
-
 jobs:
   test:
+    strategy:
+      matrix:
+        elixir: [1.9.4, 1.12.1]
+        otp: [22.2, 24.0.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
       - v*
   pull_request:
 
+strategy:
+  matrix:
+    elixir: [1.9.4, 1.12.1]
+    otp: [22.2, 24.0.2]
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "22.2"
-          elixir-version: "1.9.4"
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
       - run: mix deps.get
       - run: mix test


### PR DESCRIPTION
There were some breaking changes between those 2 versions of Erlang and because of that, code needed to be updated inside this package (https://github.com/dvcrn/binance.ex/pull/48) - this PR is updating the GitHub CI to test for version 1.12.1 + OTP 22.2 as well as 1.12.1 + OTP 24.0.2