### PR TITLE
add: change the config keys from hardcoded to env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ end
 
 ```
 config :binance,
-  api_key: "xxx",
-  secret_key: "xxx",
+  api_key: System.get_env("BINANCE_API_KEY") || raise("BINANCE_API_KEY"),
+  secret_key: System.get_env("BINANCE_SECRET_KEY") || raise("BINANCE_SECRET_KEY"),
   end_point: "https://api.binance.us" # Add for the US API end point. The default is for "https://api.binance.com"
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,8 +3,8 @@
 use Mix.Config
 
 config :binance,
-  api_key: "",
-  secret_key: "",
+  api_key: System.get_env("BINANCE_API_KEY") || raise("BINANCE_API_KEY"),
+  secret_key: System.get_env("BINANCE_SECRET_KEY") || raise("BINANCE_SECRET_KEY"),
   end_point: "https://api.binance.com"
 
 config :exvcr,

--- a/lib/binance.ex
+++ b/lib/binance.ex
@@ -783,4 +783,44 @@ defmodule Binance do
       err -> err
     end
   end
+
+  @doc """
+  Cancels all active orders on a symbol. This includes OCO orders.
+
+  Symbol and timestamp must be sent.
+
+  Returns `{:ok, %Binance.Order{}}` or `{:error, reason}`.
+
+  Weight: 1
+
+  Info: https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#cancel-all-open-orders-on-a-symbol-trade
+  """
+  def cancel_all_orders(
+        symbol,
+        timestamp,
+        recv_window \\ nil
+      ) do
+    api_key = Application.get_env(:binance, :api_key)
+    secret_key = Application.get_env(:binance, :secret_key)
+
+    arguments =
+      %{
+        symbol: symbol,
+        timestamp: timestamp
+      }
+      |> Map.merge(unless(is_nil(recv_window), do: %{recvWindow: recv_window}, else: %{}))
+
+    arguments
+    |> IO.inspect()
+
+    case HTTPClient.delete_binance("/api/v3/openOrders", arguments, secret_key, api_key) do
+      {:ok, data} ->
+        # data
+
+        {:ok, Enum.map(data, &Binance.Order.new(&1))}
+
+      err ->
+        err
+    end
+  end
 end

--- a/lib/binance/config.ex
+++ b/lib/binance/config.ex
@@ -1,0 +1,8 @@
+defmodule Binance.Config do
+  @moduledoc """
+  Provides configuration keys settings during the runtime.
+  """
+  def set(:api_key, value), do: Application.put_env(:binance, :api_key, value)
+  def set(:secret_key, value), do: Application.put_env(:binance, :secret_key, value)
+  end
+


### PR DESCRIPTION
It's better to use env var to manage config keys

source: https://12factor.net/config