### PR TITLE
add: change the config keys from hardcoded to env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@ def deps do
 end
 ```
 
-2. Add your Binance API credentials to your `config.exs` file, like so (you can create a new API
+2. Export your Binance API credentials, like so (you can create a new API
    key [here](https://www.binance.com/en/my/settings/api-management)):
 
 ```
-config :binance,
-  api_key: "xxx",
-  secret_key: "xxx",
-  end_point: "https://api.binance.us" # Add for the US API end point. The default is for "https://api.binance.com"
+export BINANCE_API_KEY=****************************************************************
+export BINANCE_SECRET_KEY==************************************************************
 ```
 
 ## Usage

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,8 +3,8 @@
 use Mix.Config
 
 config :binance,
-  api_key: "",
-  secret_key: "",
+  api_key: System.get_env("BINANCE_API_KEY") || raise("BINANCE_API_KEY is not set"),
+  secret_key: System.get_env("BINANCE_SECRET_KEY") || raise("BINANCE_SECRET_KEY is not set"),
   end_point: "https://api.binance.com"
 
 config :exvcr,

--- a/lib/binance/config.ex
+++ b/lib/binance/config.ex
@@ -1,0 +1,14 @@
+defmodule Binance.Config do
+  @moduledoc """
+  Provides configuration keys settings during the runtime.
+
+  Try binance.ex with iex:
+
+  Binance.Config.set(:api_key, "************")
+  Binance.Config.set(:secret_key, "***********")
+
+  """
+  def set(:api_key, value), do: Application.put_env(:binance, :api_key, value)
+  def set(:secret_key, value), do: Application.put_env(:binance, :secret_key, value)
+  end
+


### PR DESCRIPTION
It's better to use env var to manage config keys

source: https://12factor.net/config