### PR TITLE
added type specs to Binance.OrderResponse structure

### DIFF
--- a/lib/binance/order_response.ex
+++ b/lib/binance/order_response.ex
@@ -1,4 +1,9 @@
 defmodule Binance.OrderResponse do
+  @moduledoc """
+  Response tructure for POST /api/v3/order endpoint.
+  All prices and quantities are string representation of floats with 8 decimals (eg: "orig_qty": "10.00000000")
+  """
+
   defstruct [
     :client_order_id,
     :executed_qty,
@@ -14,4 +19,33 @@ defmodule Binance.OrderResponse do
   ]
 
   use ExConstructor
+
+  @typedoc """
+  side: "BUY" | "SELL"
+  """
+  @type side :: String.t()
+
+  @typedoc """
+  status: "NEW" | "PARTIALLY_FILLED" | "FILLED" | "CANCELED" | "PENDING_CANCEL" | "REJECTED" | "EXPIRED"
+  """
+  @type status :: String.t()
+
+  @typedoc """
+  type: "LIMIT" | "MARKET" | "STOP" | "STOP_MARKET" | "TAKE_PROFIT" | "TAKE_PROFIT_MARKET" | "LIMIT_MAKER"
+  """
+  @type type :: String.t()
+
+  @type t :: %__MODULE__{
+          client_order_id: String.t(),
+          executed_qty: String.t(),
+          order_id: non_neg_integer(),
+          orig_qty: String.t(),
+          price: String.t(),
+          side: side(),
+          status: status(),
+          symbol: String.t(),
+          time_in_force: non_neg_integer(),
+          transact_time: non_neg_integer(),
+          type: type()
+        }
 end


### PR DESCRIPTION
Hi,

this is a PR about adding type specs to `Binance.OrderResponse` structure.

Informations about types come from :

- https://binance-docs.github.io/apidocs/spot/en/#test-new-order-trade#new-order-trade
- https://github.com/sammchardy/python-binance/blob/master/binance/enums.py